### PR TITLE
update the url of virushuo

### DIFF
--- a/public/weixin.json
+++ b/public/weixin.json
@@ -19,7 +19,7 @@
   "virushuo": {
     "title": "歪理邪说",
     "openid": "oIWsFt3qoq0iKzqXrPeKhIujXtow",
-    "url": "http://blog.devep.net/virushuo/",
+    "url": "http://h.devep.net/",
     "time": ["10:00", "22:00"]
   }
 }


### PR DESCRIPTION
这个站大概是备份用，目前至少包含了一篇没有群发的文章。
